### PR TITLE
Style guide

### DIFF
--- a/docs/translating/korean.md
+++ b/docs/translating/korean.md
@@ -5,6 +5,7 @@
 ## Terms
 
 - custom - 사용자 정의
+
   custom emoji = 사용자 정의 이모티콘
   
 - message - **메시지**
@@ -24,29 +25,43 @@
    Google: 받는 사람 (Gmail)
  
  - required - 필수
-Domain for your G Suite team(required) = 당신의 G Suite team을 위한 도메인(필수)
+ 
+   Domain for your G Suite team(required) = 당신의 G Suite team을 위한 도메인(필수)
 
 ## Phrases
 
 - be subscribed to - ~을 구독하다.
-You are subscribed to this stream. = 당신은 이 스트림을 구독하고 있습니다.
+
+  You are subscribed to this stream. = 당신은 이 스트림을 구독하고 있습니다.
 
 - reply to - ~에 회신하다.
-There are no messages to reply to. = 회신할 메시지가 없습니다.
+
+  There are no messages to reply to. = 회신할 메시지가 없습니다.
 
 ## Other
 
 We Use loanwords when they are awkward in translation, and try to translate as much as possible when there is a word to replace.
 
 bot - 봇
+
 emoticon - 이모티콘
+
 emoji - 이모티콘
+
 icon - 아이콘
+
 link - 링크
+
 member - 회원
+
 menu - 메뉴
+
 mute - 뮤트
+
 navigation - 네비게이션
+
 stream - 스트림
+
 unmute - 언뮤트
+
 upload - 업로드

--- a/docs/translating/korean.md
+++ b/docs/translating/korean.md
@@ -3,6 +3,10 @@
 ## Rules
 
 ## Terms
+
+- custom - 사용자 정의
+  custom emoji = 사용자 정의 이모티콘
+  
 - message - **메시지**
   
   *(Naver, Google)*
@@ -18,7 +22,31 @@
    Naver: 받는 사람 (이메일 서비스)
    
    Google: 받는 사람 (Gmail)
+ 
+ - required - 필수
+Domain for your G Suite team(required) = 당신의 G Suite team을 위한 도메인(필수)
 
 ## Phrases
 
+- be subscribed to - ~을 구독하다.
+You are subscribed to this stream. = 당신은 이 스트림을 구독하고 있습니다.
+
+- reply to - ~에 회신하다.
+There are no messages to reply to. = 회신할 메시지가 없습니다.
+
 ## Other
+
+We Use loanwords when they are awkward in translation, and try to translate as much as possible when there is a word to replace.
+
+bot - 봇
+emoticon - 이모티콘
+emoji - 이모티콘
+icon - 아이콘
+link - 링크
+member - 회원
+menu - 메뉴
+mute - 뮤트
+navigation - 네비게이션
+stream - 스트림
+unmute - 언뮤트
+upload - 업로드

--- a/docs/translating/korean.md
+++ b/docs/translating/korean.md
@@ -3,10 +3,6 @@
 ## Rules
 
 ## Terms
-
-- custom - 사용자 정의
-
-  custom emoji = 사용자 정의 이모티콘
   
 - message - **메시지**
   
@@ -23,45 +19,11 @@
    Naver: 받는 사람 (이메일 서비스)
    
    Google: 받는 사람 (Gmail)
- 
- - required - 필수
- 
-   Domain for your G Suite team(required) = 당신의 G Suite team을 위한 도메인(필수)
 
 ## Phrases
 
-- be subscribed to - ~을 구독하다.
 
-  You are subscribed to this stream. = 당신은 이 스트림을 구독하고 있습니다.
-
-- reply to - ~에 회신하다.
-
-  There are no messages to reply to. = 회신할 메시지가 없습니다.
 
 ## Other
 
-We Use loanwords when they are awkward in translation, and try to translate as much as possible when there is a word to replace.
 
-bot - 봇
-
-emoticon - 이모티콘
-
-emoji - 이모티콘
-
-icon - 아이콘
-
-link - 링크
-
-member - 회원
-
-menu - 메뉴
-
-mute - 뮤트
-
-navigation - 네비게이션
-
-stream - 스트림
-
-unmute - 언뮤트
-
-upload - 업로드


### PR DESCRIPTION
Style Guide 

Terms
custom - 사용자 정의
custom emoji = 사용자 정의 이모티콘

It is translated as '사용자 정의' because it means 'user-specified' in the context.

required - 필수
Domain for your G Suite team(required) = 당신의 G Suite team을 위한 도메인(필수)

It is translated as '(필수)' in terms that mean essential things in context.

Phrases
be subscribed to - ~을 구독하다.
You are subscribed to this stream. = 당신은 이 스트림을 구독하고 있습니다.

reply to - ~에 회신하다.
There are no messages to reply to. = 회신할 메시지가 없습니다.

답장보다는 더 공식적인 표현인 '회신'을 사용한다.

Other
We use loanwords when they are awkward in translation, and try to translate as much as possible when there is a word to replace.

bot - 봇
emoticon - 이모티콘
emoji - 이모티콘
icon - 아이콘
link - 링크
member - 회원
menu - 메뉴
mute - 뮤트
navigation - 네비게이션
stream - 스트림
unmute - 언뮤트
upload - 업로드